### PR TITLE
Update toc to display help section

### DIFF
--- a/toc
+++ b/toc
@@ -36,7 +36,6 @@ Compare and Comply for IBM Cloud Private
     information-security.md
     /watson/watson-using-sdks
     [Watson GitHub repos](https://github.com/watson-developer-cloud)
-    
     {: .navgroup-end}
 
     {: .navgroup id="help"}


### PR DESCRIPTION
Relnotes was showing up under reference because of blank line before the navgroup-end.